### PR TITLE
Using envirnment variables with command instead of shell 

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,14 +41,14 @@
     GOPATH: "{{ go_path }}"
 
 - name: Get dependencies
-  shell: "{{ go_path }}/bin/godep get"
+  command: "{{ go_path }}/bin/godep get"
   args:
     chdir: "{{ service_dir }}/{{ item.name }}"
-  sudo: true
-  sudo_user: "{{ user }}"
   environment:
     GOPATH: "{{ go_path }}"
     PATH: "{{ ansible_env.PATH }}:{{ ansible_env.HOME }}/go/bin:/usr/local/go/bin"
+  sudo: true
+  sudo_user: "{{ user }}"
   with_items: "{{ services }}"
 
 - name: Config file


### PR DESCRIPTION
there are issues with the environment variables using the `shell` directive. It was changed for `command` 
